### PR TITLE
fix: load config via file URL for Windows (#2)

### DIFF
--- a/examples/basic-app/package.json
+++ b/examples/basic-app/package.json
@@ -13,7 +13,7 @@
     "hono": "^4.8.2"
   },
   "devDependencies": {
-    "@rcmade/hono-docs": "^1.0.30",
+    "@rcmade/hono-docs": "latest",
     "@types/node": "^20.11.17",
     "tsx": "^4.7.1",
     "typescript": "^5.8.3"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cli",
     "generator"
   ],
+  "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -1,10 +1,9 @@
-// src/cli/loadConfig.ts
 import { resolve } from "path";
 import { existsSync } from "fs";
-// <-- import tsImport from tsx:
 import { tsImport } from "tsx/esm/api";
 import type { HonoDocsConfig } from "../types";
 import { unwrapModule } from "../utils/libDir";
+import { pathToFileURL } from "url";
 
 export async function loadConfig(configFile: string): Promise<HonoDocsConfig> {
   // 1. Resolve absolute path
@@ -16,8 +15,11 @@ export async function loadConfig(configFile: string): Promise<HonoDocsConfig> {
   // 2. Dynamically load the config via tsx's tsImport()
   let configModule: unknown;
   try {
-    // tsImport(filePath, importMetaUrl) returns the loaded module
-    configModule = await tsImport(fullPath, import.meta.url);
+    configModule = await tsImport(
+      pathToFileURL(fullPath).href,
+      import.meta.url
+    );
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (err: any) {
     throw new Error(

--- a/src/core/runGenerate.ts
+++ b/src/core/runGenerate.ts
@@ -10,7 +10,7 @@ import { getLibDir } from "../utils/libDir";
 
 export async function runGenerate(configPath: string) {
   const config = await loadConfig(configPath);
-
+console.log("-------------------------------------------------------------------")
   const rootPath = process.cwd();
   console.log("Initializing ts-morph with tsConfig:", config.tsConfigPath);
   const project = new Project({

--- a/src/core/runGenerate.ts
+++ b/src/core/runGenerate.ts
@@ -10,7 +10,6 @@ import { getLibDir } from "../utils/libDir";
 
 export async function runGenerate(configPath: string) {
   const config = await loadConfig(configPath);
-console.log("-------------------------------------------------------------------")
   const rootPath = process.cwd();
   console.log("Initializing ts-morph with tsConfig:", config.tsConfigPath);
   const project = new Project({


### PR DESCRIPTION
This PR fixes the config loading error on Windows:

> Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'

Changes:
- Convert resolved config path to a `file://` URL via `pathToFileURL` before calling `tsImport`.
- Improve error message when config fails to load.

Fixes #2